### PR TITLE
correct upstart path

### DIFF
--- a/node_exporter/files/upstart/node_exporter.conf
+++ b/node_exporter/files/upstart/node_exporter.conf
@@ -6,4 +6,4 @@ stop on starting rc RUNLEVEL=[016]
 respawn
 respawn limit unlimited
 
-exec /usr/bin/node_exporter --web.listen-address={{ salt['pillar.get']('node_exporter:config:listen-address') }} {% for item in salt['pillar.get']('node_exporter:config:collectors' %)} --collector.{{item}} {% endfor %}
+exec /opt/node_exporter/node_exporter --web.listen-address={{ salt['pillar.get']('node_exporter:config:listen-address') }} {% for item in salt['pillar.get']('node_exporter:config:collectors' %)} --collector.{{item}} {% endfor %}


### PR DESCRIPTION
Corrects the upstart path from `/usr/bin/` to `/opt/node_exporter`